### PR TITLE
Add Trusted Committer career path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ Within this project you'll find the following documents:
 * [Code Review Process](/doc/code-review-process.md)
 * [How to install/use this project](/INSTALL.md)
 * [Governance model](/doc/governance.md)
+* [Trusted Commiter Career Path](/doc/tc-career-path.md) (how to become a Trusted Commiter)
 * [Code of conduct](/doc/code-of-conduct.md)
 * [Project license](/LICENSE)

--- a/doc/tc-career-path.md
+++ b/doc/tc-career-path.md
@@ -1,0 +1,19 @@
+# Trusted committer career path
+
+According to [InnerSource Learning Path](https://innersourcecommons.org/learn/learning-path/trusted-committer/01/). The Trusted Committers (TCs from now on) are expected to be responsible of several project aspects like:
+* Ensuring certain quality
+* Keeping the community healthy
+* Reducing the barriers to making contributions
+* Upleveling the community
+* Advocating the community’s needs
+
+We see a TC as someone that is a relevant part of the community. To identify TC candidates we look for people that:
+* Answer issues. Help others to solve their doubts and problems, showing their knowledge about the project.
+* Are polite and welcoming to newcomers, offering help.
+* Make contributions to improve the code or add new functionalities.
+* Participate in code reviews in a constructive way, even when they are not allowed to approve or merge the changes. Of course it is not mandatory, just a possibility if you have the knowledge to help.
+* Participate in public conversation within the community.
+* Know the community and they are also known and respected by the community.
+* Their contributions are reliable, they learned how to send proper Pull Requests.
+
+The existing project TCs will be aware of those actions and whenever they feel there is a new candidate to be TC, they can propose that person to be a TC. They should send a message to the rest of the TCs mentioning the merits they consider noteworthy. This message must be public, sent to one of [the official communication channels](https://github.com/SantanderInnerSource/innersource-project-template/blob/main/doc/governance.md#collaboration-tools), and the rest of TCs will answer `+1` to approve the proposal, or reasoning why they think that person is still not ready to be TC.


### PR DESCRIPTION
This document details the basic responsibilities we expect from
a Trusted Committer as well as the main tasks any contributor
can start helping with in order to be candidates for the
Trusted Committer role.